### PR TITLE
ci: restrict perf workflow token permissions

### DIFF
--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   require-production-profile:
     if: ${{ vars.PERF_PROFILE != '' }}


### PR DESCRIPTION
## What
- Add explicit read-only workflow permissions to the perf-enforced workflow.

## Why
- Clears the open code-scanning workflow-permissions alert by avoiding the default write-capable token posture.

## How
- Set top-level `permissions: contents: read`; existing job-level read permissions remain unchanged.

## Testing
- Commands run: `python3` YAML parse for `.github/workflows/perf-enforced.yml`; GitHub compare check.
- Results: Workflow YAML parsed successfully; remote branch diff contains only `.github/workflows/perf-enforced.yml`.

## Performance impact
- Bundle delta: N/A
- Build time delta: N/A
- Lighthouse delta: N/A
- API latency delta: N/A
- DB query delta: N/A

## Risk / Notes
- Low risk; this workflow only needs repository read access for checkout and local checks.

## Screenshots (UI only)
- N/A

## Lockfile rationale (if lockfile changed)
- N/A

## Baseline governance (if .perf-baselines changed)
- `perf-baseline-update` label applied: N/A
- Reviewer signoff: N/A
- Rollback note: Revert this workflow-only commit if a permission regression appears.